### PR TITLE
Set expiry for feed files based on last modified time

### DIFF
--- a/roles/clojars/templates/clojars.nginx.conf.j2
+++ b/roles/clojars/templates/clojars.nginx.conf.j2
@@ -64,6 +64,10 @@ server {
       # send uploads to webapp
       proxy_pass http://clojars-web;
     }
+    # set expiry to 1h after last-modified time for all-jars, all-poms and feed
+    location ~ ^/repo/(all-jars\.clj(\.gz)?|all-poms\.txt(\.gz)?|feed\.clj\.gz)(\.md5|\.sha1)?$ {
+      expires modified 1h5m;
+    }
   }
 
   location @clojars_webapp {


### PR DESCRIPTION
This additional location rule overwrites the default expiry of one week for `all-jars.clj`, `all-poms.txt`, `feed.clj` and their gz/sha1/md5 companions. The new expiry date is set to 1 hour and 5 minutes (5 minutes to allow some slack for the cronjobs) after the file was last modified, which means clients can utilise the HTTP Expiry date/max-age instead of ignoring them completely.

I have not tested this with the entire config, only with nginx. I would be amazed if this would affect other parts of the configuration, however.
