### PR TITLE
increase body size for opencv-native

### DIFF
--- a/roles/clojars/templates/clojars.nginx.conf.j2
+++ b/roles/clojars/templates/clojars.nginx.conf.j2
@@ -78,6 +78,10 @@ server {
     location ~ ^/repo/(all-jars\.clj(\.gz)?|all-poms\.txt(\.gz)?|feed\.clj\.gz)(\.md5|\.sha1)?$ {
       expires modified 1h5m;
     }
+
+    location /repo/opencv-native {
+       client_max_body_size 100m;
+    }
   }
 
   location /login {


### PR DESCRIPTION
This increase the size of upload to 100m just for opencv-native.
I've created a sample nginx/docker repository to show how this works:

https://github.com/hellonico/nginx-clojars-sample
