### PR TITLE
increase body size for opencv

### DIFF
--- a/roles/clojars/templates/clojars.nginx.conf.j2
+++ b/roles/clojars/templates/clojars.nginx.conf.j2
@@ -81,9 +81,9 @@ server {
 
     location /repo/opencv-native {
        client_max_body_size 100m;
-    }
-    location /repo/opencv {
-       client_max_body_size 100m;
+       limit_except GET HEAD {
+          proxy_pass http://clojars-web;
+       }
     }
   }
 

--- a/roles/clojars/templates/clojars.nginx.conf.j2
+++ b/roles/clojars/templates/clojars.nginx.conf.j2
@@ -82,6 +82,9 @@ server {
     location /repo/opencv-native {
        client_max_body_size 100m;
     }
+    location /repo/opencv {
+       client_max_body_size 100m;
+    }
   }
 
   location /login {


### PR DESCRIPTION
adding a rule for a higher size limit to the group opencv instead of opencv-native as I am not able to use opencv-native even on a new barebone leiningen project.

```
Username: hellonico
Password: 
Created /Users/niko/origami-land/opencv-build/clojars/opencv-native/target/opencv-native-0.1.0.jar
Wrote /Users/niko/origami-land/opencv-build/clojars/opencv-native/pom.xml
Need to sign 2 files with GPG
[1/2] Signing /Users/niko/origami-land/opencv-build/clojars/opencv-native/target/opencv-native-0.1.0.jar with GPG
[2/2] Signing /Users/niko/origami-land/opencv-build/clojars/opencv-native/pom.xml with GPG
Sending opencv-native/opencv-native/0.1.0/opencv-native-0.1.0.jar (9k)
    to https://repo.clojars.org/
Could not transfer artifact opencv-native:opencv-native:jar:0.1.0 from/to releases (https://repo.clojars.org): Failed to transfer file: https://repo.clojars.org/opencv-native/opencv-native/0.1.0/opencv-native-0.1.0.jar. Return code is: 405, ReasonPhrase: Not Allowed.
Sending opencv-native/opencv-native/0.1.0/opencv-native-0.1.0.pom (2k)
    to https://repo.clojars.org/
Could not transfer artifact opencv-native:opencv-native:pom:0.1.0 from/to releases (https://repo.clojars.org): Failed to transfer file: https://repo.clojars.org/opencv-native/opencv-native/0.1.0/opencv-native-0.1.0.pom. Return code is: 405, ReasonPhrase: Not Allowed.
Sending opencv-native/opencv-native/0.1.0/opencv-native-0.1.0.jar.asc (1k)
    to https://repo.clojars.org/
Could not transfer artifact opencv-native:opencv-native:jar.asc:0.1.0 from/to releases (https://repo.clojars.org): Failed to transfer file: https://repo.clojars.org/opencv-native/opencv-native/0.1.0/opencv-native-0.1.0.jar.asc. Return code is: 405, ReasonPhrase: Not Allowed.
Sending opencv-native/opencv-native/0.1.0/opencv-native-0.1.0.pom.asc (1k)
    to https://repo.clojars.org/
Could not transfer artifact opencv-native:opencv-native:pom.asc:0.1.0 from/to releases (https://repo.clojars.org): Failed to transfer file: https://repo.clojars.org/opencv-native/opencv-native/0.1.0/opencv-native-0.1.0.pom.asc. Return code is: 405, ReasonPhrase: Not Allowed.
Failed to deploy artifacts: Could not transfer artifact opencv-native:opencv-native:jar:0.1.0 from/to releases (https://repo.clojars.org): Failed to transfer file: https://repo.clojars.org/opencv-native/opencv-native/0.1.0/opencv-native-0.1.0.jar. Return code is: 405, ReasonPhrase: Not Allowed.
```