### PR TITLE
Fix packer AMI build: declare required plugins, bump packer to 1.15.1

### DIFF
--- a/ami/packer.json.pkr.hcl
+++ b/ami/packer.json.pkr.hcl
@@ -1,3 +1,16 @@
+packer {
+  required_plugins {
+    amazon = {
+      source  = "github.com/hashicorp/amazon"
+      version = "~> 1"
+    }
+    ansible = {
+      source  = "github.com/hashicorp/ansible"
+      version = "~> 1"
+    }
+  }
+}
+
 variable "aws_access_key" {
   type      = string
   sensitive = true

--- a/bin/packer
+++ b/bin/packer
@@ -5,7 +5,7 @@ set -euo pipefail
 
 DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
-TOOL_VERSION="1.8.2"
+TOOL_VERSION="1.15.1"
 TOOL=packer
 
 source "$DIR/hc_install.bash"

--- a/scripts/build_ami.sh
+++ b/scripts/build_ami.sh
@@ -9,6 +9,8 @@ cd "${dir}/../ami"
 # Find the latest Amazon Linux 2 AMI
 BASE_AMI=$(aws ec2 describe-images --owners amazon --filters "Name=name,Values=al2023-ami-2023*-arm64" --query 'sort_by(Images,&CreationDate)[-1].ImageId' --region "us-east-2" --output text)
 
+packer init packer.json.pkr.hcl
+
 packer build \
     -var aws_access_key="${AWS_ACCESS_KEY_ID}" \
     -var aws_secret_key="${AWS_SECRET_ACCESS_KEY}" \


### PR DESCRIPTION
## Summary
`scripts/build_ami.sh` was failing with `Error: Unknown source type amazon-ebs` because:

1. The HCL config had no `required_plugins` block. Since packer 1.7, external plugins (including `amazon-ebs` and `ansible-local`) are no longer bundled and must be declared.
2. `build_ami.sh` didn't run `packer init` before `packer build`.
3. The pinned packer version (1.8.2) is old — bumping to 1.15.1 (latest) for better auto-install behavior and to stay current.

## Changes
- `ami/packer.json.pkr.hcl`: add a `packer { required_plugins { amazon, ansible } }` block.
- `scripts/build_ami.sh`: run `packer init packer.json.pkr.hcl` before `packer build`.
- `bin/packer`: bump `TOOL_VERSION` from 1.8.2 → 1.15.1.

## Test plan
- [x] `bin/packer version` → `Packer v1.15.1`
- [x] `cd ami && packer init packer.json.pkr.hcl` → installs the amazon plugin cleanly
- [ ] Full `scripts/build_ami.sh` produces a new AMI end-to-end (needs AWS creds + time — not run locally)