### PR TITLE
Require IMDSv2 for production instances

### DIFF
--- a/terraform/asg.tf
+++ b/terraform/asg.tf
@@ -63,12 +63,10 @@ resource "aws_launch_template" "prod_launch_template" {
   }
 
   metadata_options {
-    # cognitect's aws.api only supports IMDSv1 for getting instance credentials,
-    # but IMDSv1 is disabled by default on AL2023 in favor for IMDSv2. This allows
-    # IMDSv1 to be used.
-    http_tokens = "optional"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
 
-    # A TF bug requires us to set this as well for the above option to be
+    # A TF bug requires us to set this as well for the token option to be
     # applied. See
     # https://github.com/hashicorp/terraform-provider-aws/issues/25909#issuecomment-1218625304
     http_endpoint = "enabled"


### PR DESCRIPTION
## Summary

- require IMDSv2 tokens in the production EC2 launch template
- limit metadata responses to one network hop
- remove the obsolete aws.api IMDSv1 compatibility comment

## Verification

- terraform fmt -check
- terraform validate with Terraform 1.12.2 and AWS provider 6.45.0
- exercised com.cognitect.aws/api 0.8.774 against a local IMDSv2-only endpoint using its real HTTP client; the default credentials chain obtained a token and attached it to both role credential requests
- Checked Cloudwatch Metrics - production MetadataNoToken at 0.0 over 24 hours; MetadataNoTokenRejected had no datapoints, as expected while tokens remain optional

## Rollout

No infrastructure changes were applied. After review, a human should apply the Terraform change and cycle the instance, then confirm the app and deployment scripts start normally and MetadataNoTokenRejected remains zero.