### PR TITLE
Move production RDS into private subnets

### DIFF
--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -9,6 +9,7 @@ data "aws_ssm_parameter" "db_username" {
 resource "aws_security_group" "allow_postgres" {
   name        = "allow_postgres2"
   description = "Allow access to postgres server"
+  vpc_id      = aws_vpc.default.id
 
   ingress {
     from_port       = 5432
@@ -25,16 +26,24 @@ resource "aws_security_group" "allow_postgres" {
   }
 }
 
+resource "aws_db_subnet_group" "production" {
+  name        = "clojars-production"
+  description = "Private subnets for the production database"
+  subnet_ids  = values(aws_subnet.database)[*].id
+}
+
 resource "aws_db_instance" "production" {
   allocated_storage            = 20
   backup_retention_period      = 7
+  db_subnet_group_name         = aws_db_subnet_group.production.name
+  deletion_protection          = true
   engine                       = "postgres"
   engine_version               = "18.4"
   identifier                   = "clojars-production2"
   instance_class               = "db.t4g.small"
   db_name                      = "clojars"
   password                     = data.aws_ssm_parameter.db_password.value
-  publicly_accessible          = true
+  publicly_accessible          = false
   performance_insights_enabled = true
   storage_type                 = "gp2"
   username                     = data.aws_ssm_parameter.db_username.value

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -6,16 +6,52 @@ locals {
     "subnet-d27c58a8", # us-east-2b
     "subnet-5cbf3310"  # us-east-2c
   ]
+
+  # Keep database subnets at the top of the default VPC's CIDR range so they
+  # don't overlap its /20 default subnets.
+  database_subnets = {
+    "us-east-2a" = 240
+    "us-east-2b" = 241
+  }
 }
 
 resource "aws_vpc" "default" {
   assign_generated_ipv6_cidr_block = true
 }
 
+resource "aws_subnet" "database" {
+  for_each = local.database_subnets
+
+  availability_zone       = each.key
+  cidr_block              = cidrsubnet(aws_vpc.default.cidr_block, 8, each.value)
+  map_public_ip_on_launch = false
+  vpc_id                  = aws_vpc.default.id
+
+  tags = {
+    Name = "database-${each.key}"
+  }
+}
+
+# This route table deliberately has no route to an internet or NAT gateway.
+resource "aws_route_table" "database" {
+  vpc_id = aws_vpc.default.id
+
+  tags = {
+    Name = "database-private"
+  }
+}
+
+resource "aws_route_table_association" "database" {
+  for_each = aws_subnet.database
+
+  route_table_id = aws_route_table.database.id
+  subnet_id      = each.value.id
+}
+
 resource "aws_default_network_acl" "default" {
   default_network_acl_id = aws_vpc.default.default_network_acl_id
 
-  subnet_ids = local.subnet_ids
+  subnet_ids = concat(local.subnet_ids, values(aws_subnet.database)[*].id)
 
   // We see lots of connection attempts from this IP, and the TLS negotiation
   // almost always fails. This is expensive (it quadrupled our LB expenditure),


### PR DESCRIPTION
## Summary

- add dedicated private database subnets with no internet or NAT route
- move the production RDS instance into a private DB subnet group and disable public accessibility
- enable RDS deletion protection